### PR TITLE
fix lettuceConnectionFactory initialized

### DIFF
--- a/lightweight-rate-limiter-core/src/main/java/io/redick01/ratelimiter/redis/RedisTemplateInitialization.java
+++ b/lightweight-rate-limiter-core/src/main/java/io/redick01/ratelimiter/redis/RedisTemplateInitialization.java
@@ -37,7 +37,8 @@ public class RedisTemplateInitialization {
             //spring data redisTemplate
             if (Objects.isNull(Singleton.INST.get(RedisTemplate.class))) {
                 LettuceConnectionFactory lettuceConnectionFactory = createLettuceConnectionFactory(redisConfig);
-                RedisTemplate<String, Object> template = new RedisTemplate<>();
+	            lettuceConnectionFactory.afterPropertiesSet();
+	            RedisTemplate<String, Object> template = new RedisTemplate<>();
                 RedisSerializer<String> serializer = new StringRedisSerializer();
                 template.setConnectionFactory(lettuceConnectionFactory);
                 template.setKeySerializer(serializer);


### PR DESCRIPTION
LettuceConnectionFactory was not initialized through afterPropertiesSet() lead to nullPointerException
so active call afterPropertiesSet() method.
![Uploading problem.png…]()
